### PR TITLE
refactor: rename default group to 'ansible'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,12 @@
   ansible.builtin.lineinfile:
     path: /etc/clustershell/groups.conf
     regexp: '^default:'
-    line: 'default: default'
+    line: 'default: ansible'
 
 - name: Define default groups
   ansible.builtin.template:
-    src: default.yaml.j2
-    dest: /etc/clustershell/groups.d/default.yaml
+    src: ansible.yaml.j2
+    dest: /etc/clustershell/groups.d/ansible.yaml
     owner: root
     group: root
     mode: 0644

--- a/templates/ansible.yaml.j2
+++ b/templates/ansible.yaml.j2
@@ -1,0 +1,5 @@
+## {{ ansible_managed }} ##
+
+{# The Ansible groups dict must be in the ansible dictionary #}
+{% set ansible = {'ansible': groups} %}
+{{ ansible | to_nice_yaml(indent=2) }}

--- a/templates/default.yaml.j2
+++ b/templates/default.yaml.j2
@@ -1,5 +1,0 @@
-## {{ ansible_managed }} ##
-
-{# The Ansible groups dict must be in the default dictionary #}
-{% set default = {'default': groups} %}
-{{ default | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
Since the content of the default group is build from the Ansible
inventory, make it clear and use 'ansible' as default group name.