### PR TITLE
feat: Add new filter nodeset

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ based on the groups declared in the Ansible inventory.
 
 [1]: https://cea-hpc.github.io/clustershell/
 
+Requirements
+------------
+
+The below Python requirements are needed on the host that executes this role.
+
+ - clustershell
+
 Role Variables
 --------------
 

--- a/filter_plugins/nodeset.py
+++ b/filter_plugins/nodeset.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+from ClusterShell.NodeSet import NodeSet
+
+def nodeset(nodes_list):
+    '''Convert a list of nodes to ClusterShell's NodeSet'''
+    nodeset = NodeSet(",".join(nodes_list))
+    return nodeset
+
+class FilterModule(object):
+    ''' NodeSet Jinja2 filter. '''
+
+    def filters(self):
+        return {
+            'nodeset': nodeset,
+        }

--- a/templates/ansible.yaml.j2
+++ b/templates/ansible.yaml.j2
@@ -1,5 +1,6 @@
 ## {{ ansible_managed }} ##
 
-{# The Ansible groups dict must be in the ansible dictionary #}
-{% set ansible = {'ansible': groups} %}
-{{ ansible | to_nice_yaml(indent=2) }}
+ansible:
+{% for group in groups | sort %}
+    {{ group }}: '{{ groups[group] | nodeset }}'
+{% endfor %}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     ansible3: ansible>=3.0,<4.0
     ansible4: ansible>=4.0,<5.0
     ansible-lint
+    clustershell
     flake8
     jmespath
     netaddr

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3-ansible{29,210,3,4}
+envlist = py3-ansible{7,8}
 skipsdist = true
 
 [testenv]
@@ -10,15 +10,13 @@ passenv =
     PY_COLORS
     ANSIBLE_FORCE_COLOR
 deps =
-    ansible29: ansible>=2.9,<2.10
-    ansible210: ansible>=2.10,<3.0
-    ansible3: ansible>=3.0,<4.0
-    ansible4: ansible>=4.0,<5.0
-    ansible-lint
+    ansible7: ansible>=7.0,<8.0
+    ansible8: ansible>=8.0,<9.0
     clustershell
     flake8
     jmespath
     netaddr
-    molecule[docker]
+    molecule
+    molecule-plugins[docker]
 commands =
     molecule test


### PR DESCRIPTION
This is kind of recursive, but use ClusterShell's nodeset to write the configuration file. This requires to install the Python package `clustershell` on the Ansible controller.