### PR TITLE
feat: Add support of sshpass mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - ubuntu2404
         scenario:
           - default
+          - sshpass
           - sudo
 
     steps:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ Role Variables
 
     ---
     # List of packages to install
-    clustershell_packages: clustershell
+    clustershell_packages:
+      - clustershell
+
+    # Configuration for sshpass mode (added in ClusterShell 1.9)
+    # Set 'clustershell_sshpass: true' to enable sshpass mode
+    clustershell_sshpass: false
+    clustershell_sshpass_password_prompt: 'yes'
+    clustershell_sshpass_ssh_path: /usr/bin/sshpass /usr/bin/ssh
+    clustershell_sshpass_scp_path: /usr/bin/sshpass /usr/bin/scp
+    clustershell_sshpass_ssh_options: -oBatchMode=no -oStrictHostKeyChecking=no
 
     # Configuration for sudo mode (added in ClusterShell 1.9)
     # Set 'clustershell_sudo: true' to enable sudo mode

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
-clustershell_packages: clustershell
+clustershell_packages:
+  - clustershell
+
+# Configuration for sshpass mode (added in ClusterShell 1.9)
+# Set 'clustershell_sshpass: true' to enable sshpass mode
+clustershell_sshpass: false
+clustershell_sshpass_password_prompt: 'yes'
+clustershell_sshpass_ssh_path: /usr/bin/sshpass /usr/bin/ssh
+clustershell_sshpass_scp_path: /usr/bin/sshpass /usr/bin/scp
+clustershell_sshpass_ssh_options: -oBatchMode=no -oStrictHostKeyChecking=no
 
 # Configuration for sudo mode (added in ClusterShell 1.9)
 # Set 'clustershell_sudo: true' to enable sudo mode

--- a/molecule/sshpass/converge.yml
+++ b/molecule/sshpass/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    clustershell_sshpass: true
+    clustershell_sshpass_password_prompt: 'yes'
+    clustershell_sshpass_ssh_path: fake_ssh_path
+    clustershell_sshpass_scp_path: fake_scp_path
+    clustershell_sshpass_ssh_options: fake_ssh_options
+  tasks:
+    - name: "Include clustershell"
+      include_role:
+        name: "btravouillon.clustershell"

--- a/molecule/sshpass/molecule.yml
+++ b/molecule/sshpass/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/molecule/sshpass/prepare.yml
+++ b/molecule/sshpass/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/sshpass/verify.yml
+++ b/molecule/sshpass/verify.yml
@@ -1,0 +1,57 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Collect package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Assert package is installed
+      ansible.builtin.assert:
+        that: "'{{ item }}' in ansible_facts.packages"
+      loop:
+        - clustershell
+        - sshpass
+
+    - name: Retrieve file /etc/clustershell/clush.conf.d/sshpass.conf
+      ansible.builtin.stat:
+        path: /etc/clustershell/clush.conf.d/sshpass.conf
+      register: reg_file_sshpass
+      changed_when: false
+
+    - name: Assert file /etc/clustershell/clush.conf.d/sshpass.conf exists
+      ansible.builtin.assert:
+        that:
+          - reg_file_sshpass.stat.exists
+          - reg_file_sshpass.stat.mode == '0644'
+          - reg_file_sshpass.stat.pw_name == 'root'
+          - reg_file_sshpass.stat.gr_name == 'root'
+
+    - name: Read /etc/clustershell/clush.conf.d/sshpass.conf
+      ansible.builtin.slurp:
+        src: /etc/clustershell/clush.conf.d/sshpass.conf
+      register: sshpass_conf
+
+    - name: Display /etc/clustershell/clush.conf.d/sshpass.conf
+      ansible.builtin.debug:
+        msg: "{{ sshpass_conf['content'] | b64decode }}"
+
+    - name: Check 'password_prompt=yes'
+      ansible.builtin.assert:
+        that: "{{ sshpass_conf['content'] | b64decode |
+                 regex_findall(('^password_prompt: yes'), multiline=True) | length == 1 }}"
+
+    - name: Check 'ssh_path=fake_ssh_path'
+      ansible.builtin.assert:
+        that: "{{ sshpass_conf['content'] | b64decode |
+                regex_findall(('^ssh_path: fake_ssh_path$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'scp_path=fake_scp_path'
+      ansible.builtin.assert:
+        that: "{{ sshpass_conf['content'] | b64decode |
+                regex_findall(('^scp_path: fake_scp_path$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'ssh_options=fake_ssh_options'
+      ansible.builtin.assert:
+        that: "{{ sshpass_conf['content'] | b64decode |
+                regex_findall(('^ssh_options: fake_ssh_options$'), multiline=True) | length == 1 }}"

--- a/molecule/sudo/verify.yml
+++ b/molecule/sudo/verify.yml
@@ -2,6 +2,17 @@
 - name: Verify
   hosts: all
   tasks:
+    - name: Collect package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Assert package is installed
+      ansible.builtin.assert:
+        that: "'{{ item }}' in ansible_facts.packages"
+      loop:
+        - clustershell
+        - sudo
+
     - name: Retrieve file /etc/clustershell/clush.conf.d/sudo.conf
       ansible.builtin.stat:
         path: /etc/clustershell/clush.conf.d/sudo.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 - name: Install ClusterShell
   ansible.builtin.package:
-    name: "{{ clustershell_packages }}"
+    name: "{{
+      clustershell_packages +
+      clustershell_sshpass | ternary(['sshpass'], []) +
+      clustershell_sudo    | ternary(['sudo'], [])
+    }}"
     state: present
 
 - name: Set default group name
@@ -17,19 +21,29 @@
     group: root
     mode: "0644"
 
+- name: Ensure clush.conf.d exists
+  when: clustershell_sshpass | bool or clustershell_sudo | bool
+  ansible.builtin.file:
+    path: /etc/clustershell/clush.conf.d/
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Configure sshpass mode
+  when: clustershell_sshpass | bool
+  ansible.builtin.template:
+    src: sshpass.conf.j2
+    dest: /etc/clustershell/clush.conf.d/sshpass.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Configure sudo mode
   when: clustershell_sudo | bool
-  block:
-    - ansible.builtin.file:
-        path: /etc/clustershell/clush.conf.d/
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-
-    - ansible.builtin.template:
-        src: sudo.conf.j2
-        dest: /etc/clustershell/clush.conf.d/sudo.conf
-        owner: root
-        group: root
-        mode: "0644"
+  ansible.builtin.template:
+    src: sudo.conf.j2
+    dest: /etc/clustershell/clush.conf.d/sudo.conf
+    owner: root
+    group: root
+    mode: "0644"

--- a/templates/sshpass.conf.j2
+++ b/templates/sshpass.conf.j2
@@ -1,0 +1,7 @@
+## {{ ansible_managed }} ##
+
+[mode:sshpass]
+password_prompt: {{ clustershell_sshpass_password_prompt }}
+ssh_path: {{ clustershell_sshpass_ssh_path }}
+scp_path: {{ clustershell_sshpass_scp_path }}
+ssh_options: {{ clustershell_sshpass_ssh_options }}


### PR DESCRIPTION
The sshpass mode is disabled by default.

This change makes sure the sshpass package is installed on the host. Implement the same logic for the sudo package since the sudo mode is somewhat similar to sshpass mode.

Since `clustershell_packages` can be a list, make sure the default value is a list, even if there is a single item. This is required to add items to the list of packages to install when sshpass mode or sudo mode are enabled.