### PR TITLE
feat: Add support of group bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - ubuntu2404
         scenario:
           - default
+          - group_bindings
           - sshpass
           - sudo
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ Role Variables
     clustershell_packages:
       - clustershell
 
+    # List of example group bindings to enable
+    # e.g. to install Slurm group bindings:
+    # clustershell_group_bindings:
+    #   - slurm
+    #
+    # This will copy slurm.conf.example to slurm.conf
+    clustershell_group_bindings: []
+
+    # List of custom group bindings
+    # clustershell_group_bindings_custom:
+    #   - name: racksdb
+    #     content: |
+    #       [racksdb]
+    #       map:     racksdb nodes --infrastructure atlas --tags $GROUP --list
+    #       all:     racksdb nodes --infrastructure atlas --list
+    #       list:    racksdb tags  --infrastructure atlas --on-nodes
+    #       reverse: racksdb tags  --node $NODE
+    #
+    # This will install file racksdb.conf
+    clustershell_group_bindings_custom: []
+
+    # List of group bindings to remove
+    clustershell_group_bindings_remove: []
+
     # Configuration for sshpass mode (added in ClusterShell 1.9)
     # Set 'clustershell_sshpass: true' to enable sshpass mode
     clustershell_sshpass: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,15 @@
 clustershell_packages:
   - clustershell
 
+# List of example group bindings to enable
+clustershell_group_bindings: []
+
+# List of custom group bindings
+clustershell_group_bindings_custom: []
+
+# List of group bindings to remove
+clustershell_group_bindings_remove: []
+
 # Configuration for sshpass mode (added in ClusterShell 1.9)
 # Set 'clustershell_sshpass: true' to enable sshpass mode
 clustershell_sshpass: false

--- a/molecule/group_bindings/converge.yml
+++ b/molecule/group_bindings/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    clustershell_group_bindings:
+      - genders
+      - slurm
+    clustershell_group_bindings_custom:
+      - name: racksdb
+        content: |
+          [racksdb]
+          map:     racksdb nodes --infrastructure atlas --tags $GROUP --list
+          all:     racksdb nodes --infrastructure atlas --list
+          list:    racksdb tags  --infrastructure atlas --on-nodes
+          reverse: racksdb tags  --node $NODE
+  tasks:
+    - name: "Include clustershell"
+      include_role:
+        name: "btravouillon.clustershell"

--- a/molecule/group_bindings/molecule.yml
+++ b/molecule/group_bindings/molecule.yml
@@ -1,0 +1,1 @@
+../default/molecule.yml

--- a/molecule/group_bindings/prepare.yml
+++ b/molecule/group_bindings/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/group_bindings/verify.yml
+++ b/molecule/group_bindings/verify.yml
@@ -1,0 +1,79 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+    - name: Retrieve file /etc/clustershell/groups.conf.d/genders.conf
+      ansible.builtin.stat:
+        path: /etc/clustershell/groups.conf.d/genders.conf
+      register: reg_file_genders
+      changed_when: false
+
+    - name: Assert file /etc/clustershell/groups.conf.d/genders.conf exists
+      ansible.builtin.assert:
+        that:
+          - reg_file_genders.stat.exists
+          - reg_file_genders.stat.mode == '0644'
+          - reg_file_genders.stat.pw_name == 'root'
+          - reg_file_genders.stat.gr_name == 'root'
+
+    - name: Retrieve file /etc/clustershell/groups.conf.d/slurm.conf
+      ansible.builtin.stat:
+        path: /etc/clustershell/groups.conf.d/slurm.conf
+      register: reg_file_slurm
+      changed_when: false
+
+    - name: Assert file /etc/clustershell/groups.conf.d/slurm.conf exists
+      ansible.builtin.assert:
+        that:
+          - reg_file_slurm.stat.exists
+          - reg_file_slurm.stat.mode == '0644'
+          - reg_file_slurm.stat.pw_name == 'root'
+          - reg_file_slurm.stat.gr_name == 'root'
+
+    - name: Retrieve file /etc/clustershell/groups.conf.d/racksdb.conf
+      ansible.builtin.stat:
+        path: /etc/clustershell/groups.conf.d/racksdb.conf
+      register: reg_file_racksdb
+      changed_when: false
+
+    - name: Assert file /etc/clustershell/groups.conf.d/racksdb.conf exists
+      ansible.builtin.assert:
+        that:
+          - reg_file_racksdb.stat.exists
+          - reg_file_racksdb.stat.mode == '0644'
+          - reg_file_racksdb.stat.pw_name == 'root'
+          - reg_file_racksdb.stat.gr_name == 'root'
+
+    - name: Read /etc/clustershell/groups.conf.d/racksdb.conf
+      ansible.builtin.slurp:
+        src: /etc/clustershell/groups.conf.d/racksdb.conf
+      register: racksdb_conf
+
+    - name: Display /etc/clustershell/groups.conf.d/racksdb.conf
+      ansible.builtin.debug:
+        msg: "{{ racksdb_conf['content'] | b64decode }}"
+
+    - name: Check '[racksdb]' header
+      ansible.builtin.assert:
+        that: "{{ racksdb_conf['content'] | b64decode |
+                 regex_findall(('^\\[racksdb\\]$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'map=racksdb nodes --infrastructure atlas --tags $GROUP --list'
+      ansible.builtin.assert:
+        that: "{{ racksdb_conf['content'] | b64decode |
+                 regex_findall(('^map:     racksdb nodes --infrastructure atlas --tags \\$GROUP --list$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'all=racksdb nodes --infrastructure atlas --list'
+      ansible.builtin.assert:
+        that: "{{ racksdb_conf['content'] | b64decode |
+                regex_findall(('^all:     racksdb nodes --infrastructure atlas --list$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'list=racksdb tags  --infrastructure atlas --on-nodes'
+      ansible.builtin.assert:
+        that: "{{ racksdb_conf['content'] | b64decode |
+                regex_findall(('^list:    racksdb tags  --infrastructure atlas --on-nodes$'), multiline=True) | length == 1 }}"
+
+    - name: Check 'reverse=racksdb tags  --node $NODE'
+      ansible.builtin.assert:
+        that: "{{ racksdb_conf['content'] | b64decode |
+                regex_findall(('^reverse: racksdb tags  --node \\$NODE$'), multiline=True) | length == 1 }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,37 @@
     group: root
     mode: "0644"
 
+- name: Configure group bindings from examples
+  loop: "{{ clustershell_group_bindings }}"
+  loop_control:
+    label: "Install /etc/clustershell/groups.conf.d/{{ item }}.conf"
+  ansible.builtin.copy:
+    remote_src: true
+    src: /etc/clustershell/groups.conf.d/{{ item }}.conf.example
+    dest: /etc/clustershell/groups.conf.d/{{ item }}.conf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Configure custom group bindings
+  loop: "{{ clustershell_group_bindings_custom }}"
+  loop_control:
+    label: "Install /etc/clustershell/groups.conf.d/{{ item.name }}.conf"
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: /etc/clustershell/groups.conf.d/{{ item.name }}.conf
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Remove group bindings
+  loop: "{{ clustershell_group_bindings_remove }}"
+  loop_control:
+    label: "Remove /etc/clustershell/groups.conf.d/{{ item }}.conf"
+  ansible.builtin.file:
+    path: /etc/clustershell/groups.conf.d/{{ item }}.conf
+    state: absent
+
 - name: Ensure clush.conf.d exists
   when: clustershell_sshpass | bool or clustershell_sudo | bool
   ansible.builtin.file:


### PR DESCRIPTION
ClusterShell provides great examples which can be enabled by adding the name of the group binding to the list `clustershell_group_bindings`.

For custom group bindings, define their name and content in the list `clustershell_group_bindings_custom`.