### PR TITLE
ci: Fix warnings reported by ansible-lint

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: '2.16'
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -19,18 +19,18 @@ galaxy_info:
   # https://galaxy.ansible.com/api/v1/platforms/
   #
   platforms:
-  - name: Debian
-    versions:
-    - buster
-    - bullseye
-  - name: EL
-    versions:
-    - 7
-    - 8
-  - name: Ubuntu
-    versions:
-    - bionic
-    - focal
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - '9'
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
 
   galaxy_tags:
     - cluster

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,5 +12,5 @@
         - { name: hmock2, groups: [gmock2, common] }
 
     - name: "Include clustershell"
-      include_role:
+      ansible.builtin.include_role:
         name: "btravouillon.clustershell"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,9 +1,8 @@
 ---
 - name: Prepare
   hosts: all
-
   tasks:
     - name: "Update APT cache"
       ansible.builtin.apt:
-        update_cache: True
+        update_cache: true
       when: ansible_facts.os_family == "Debian"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -51,7 +51,7 @@
         path: /etc/clustershell/groups.d/ansible.yaml
         regexp: "{{ item }}"
         state: absent
-      check_mode: yes
+      check_mode: true
       register: reg_conf_groups_ansible
       changed_when: false
       loop:

--- a/molecule/group_bindings/converge.yml
+++ b/molecule/group_bindings/converge.yml
@@ -15,5 +15,5 @@
           reverse: racksdb tags  --node $NODE
   tasks:
     - name: "Include clustershell"
-      include_role:
+      ansible.builtin.include_role:
         name: "btravouillon.clustershell"

--- a/molecule/sshpass/converge.yml
+++ b/molecule/sshpass/converge.yml
@@ -9,5 +9,5 @@
     clustershell_sshpass_ssh_options: fake_ssh_options
   tasks:
     - name: "Include clustershell"
-      include_role:
+      ansible.builtin.include_role:
         name: "btravouillon.clustershell"

--- a/molecule/sudo/converge.yml
+++ b/molecule/sudo/converge.yml
@@ -6,5 +6,5 @@
     clustershell_sudo_command_prefix: fake_command
   tasks:
     - name: "Include clustershell"
-      include_role:
+      ansible.builtin.include_role:
         name: "btravouillon.clustershell"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{
       clustershell_packages +
       clustershell_sshpass | ternary(['sshpass'], []) +
-      clustershell_sudo    | ternary(['sudo'], [])
+      clustershell_sudo | ternary(['sudo'], [])
     }}"
     state: present
 


### PR DESCRIPTION
These warnings are reported during the role import in Ansible Galaxy. While not an issue, let's try to avoid linter warnings.